### PR TITLE
Bug/invalid time to attendance: Fix an issue on attendance view, during an invalid time.

### DIFF
--- a/src/app/login/attendance/attendance.component.ts
+++ b/src/app/login/attendance/attendance.component.ts
@@ -49,7 +49,8 @@ export class AttendanceComponent implements OnInit {
     this.attendanceService.getAttendance(this.date, hour, minute)
     .subscribe(data => {
       console.log('data: ', data);
-      this.meal = (data['result'] && data['result']['selected'].name) || '----';
+      this.meal = (data['result'] && data['result']['selected'] && data['result']['selected'].name)
+        || '----';
       this.cont = this.extractAttendance(data);
     }, error => {
       console.log(error);


### PR DESCRIPTION
Explannation: An invalid time to attendance is for example at midnight. Because there is no meal, that matches that time. 
Actual: The label: "Asistencia" is not showing anything, an javascript error is shown.
Expected: The label "Asistencia" should show dashes "----" to indicate there is no meal selected. 